### PR TITLE
add gpt-3-encoder to sql2llm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognosis/platform",
-  "version": "0.5.11",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognosis/platform",
-      "version": "0.5.11",
+      "version": "0.6.1",
       "dependencies": {
         "@babel/core": "^7.19.6",
         "@babel/parser": "^7.19.6",
@@ -29,6 +29,7 @@
         "dotenv": "^16.0.3",
         "express": "^4.18.1",
         "google-auth-library": "^8.5.2",
+        "gpt-3-encoder": "^1.1.4",
         "handlebars": "^4.7.7",
         "json2csv": "^5.0.7",
         "json5": "^2.2.1",
@@ -3926,6 +3927,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/gpt-3-encoder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/gpt-3-encoder/-/gpt-3-encoder-1.1.4.tgz",
+      "integrity": "sha512-fSQRePV+HUAhCn7+7HL7lNIXNm6eaFWFbNLOOGtmSJ0qJycyQvj60OvRlH7mee8xAMjBDNRdMXlMwjAbMTDjkg=="
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
@@ -10129,6 +10135,11 @@
           "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
         }
       }
+    },
+    "gpt-3-encoder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/gpt-3-encoder/-/gpt-3-encoder-1.1.4.tgz",
+      "integrity": "sha512-fSQRePV+HUAhCn7+7HL7lNIXNm6eaFWFbNLOOGtmSJ0qJycyQvj60OvRlH7mee8xAMjBDNRdMXlMwjAbMTDjkg=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.1",
     "google-auth-library": "^8.5.2",
+    "gpt-3-encoder": "^1.1.4",
     "handlebars": "^4.7.7",
     "json2csv": "^5.0.7",
     "json5": "^2.2.1",

--- a/src/activities/tokenizer.ts
+++ b/src/activities/tokenizer.ts
@@ -73,6 +73,17 @@ export async function tokenize_native(text: string): Promise<string[]> {
   return tokenizer.tokenize(text);
 }
 
+export async function gpt3_tokenize(text: string): Promise<number[]> {
+  let tokenizer = require('gpt-3-encoder');
+  let encoded_tokens: number[] = tokenizer.encode(text);
+  return encoded_tokens;
+}
+
+export async function gpt3_detokenize(tokens: number[]): Promise<string> {
+  let tokenizer = require('gpt-3-encoder');
+  let text = tokenizer.decode(tokens);
+  return text;
+}
 
 export async function sentence_tokenizer( text: String ): Promise< string[] > {
   throw new Error("Not implemented" );

--- a/src/workflows/sql2llm.ts
+++ b/src/workflows/sql2llm.ts
@@ -6,7 +6,7 @@ import * as sql2llm from '../activities/sql2llm';
 import { resourceLimits } from 'node:worker_threads';
 import { actionLogger } from '../activities';
 
-const { tokenize_native, sql2llm_session_multiplexer, parse_and_fix_csv } = proxyActivities< typeof activities >({ startToCloseTimeout: '10 minute' });
+const { gpt3_detokenize, gpt3_tokenize, sql2llm_session_multiplexer, parse_and_fix_csv } = proxyActivities< typeof activities >({ startToCloseTimeout: '10 minute' });
 
 export interface SQL2LLMInput extends Frame {
     dbname: string;
@@ -159,20 +159,27 @@ Database:`, {sql: q}, 1, 32, 0.0, "text-curie-001" )).replace( /^\s+/, '' ).repl
 
     if ( context )
     {
-        let context_tokens: string[] = await tokenize_native( context );
-        let context_tokensChunks: string[][] = [];
+        // TODO chunking algo that can optionally overlap chunks so we don't lose context when splitting
+        let context_tokens: number[] = await gpt3_tokenize( context );
+
+        console.log(`Tokenized ${context.length} characters into ${context_tokens.length} tokens.`);
+        let context_chunks: string[] = [];
         let chunkSize = 2048;
         for ( let i = 0; i < context_tokens.length; i += chunkSize )
         {
-            context_tokensChunks.push( context_tokens.slice(i, i + chunkSize) );
+            let context_tokens_slice: number[] = context_tokens.slice(i, i + chunkSize);
+            let context_slice = await gpt3_detokenize( context_tokens_slice );
+            context_chunks.push( context_slice );
         }
 
         let results: SQL2LLMOutput[] = [];
-        if ( context_tokensChunks.length > 1 )
+        if ( context_chunks.length > 1 )
         {
-            let promises = context_tokensChunks.map( async (chunk) => {
-                console.log( `Context chunk: ${chunk.length} tokens`);
-                let res = await sql2llm_session_multiplexer( {dbname: dbname!, fields: fields, query: q, text: q, ts: new Date(), logs: [], context: chunk.join(' ')} );
+            let promises = context_chunks.map( async (chunk) => {
+                let chunk_tokens: number[] = await gpt3_tokenize( chunk );
+                console.log( `Context chunk: ${chunk.length} characters, ${chunk_tokens.length} tokens.}`);
+                let res = await sql2llm_session_multiplexer( {dbname: dbname!, fields: fields, query: q, text: q, ts: new Date(), logs: [], context: chunk} );
+                
                 // Add result to the results array.
                 res.result.forEach( (r) => { results.push(r) } );
             });


### PR DESCRIPTION
I tested the sql2llm cli workflow manually with a short (< 2048 tokens) and a long (~7k tokens) context file and it worked in both cases.

should we create a separate issue to add unit tests to this project?

btw, maybe want to create a dev branch to merge there, so main is always stable