### PR TITLE
add sliding window text splitter

### DIFF
--- a/src/activities/__tests__/tokenizer.test.ts
+++ b/src/activities/__tests__/tokenizer.test.ts
@@ -1,7 +1,149 @@
-import { sentence_tokenizer } from '../tokenizer';
+import { split_text_by_tokens } from '../tokenizer';
 
-describe('split_text_by_tokens', () => {
-  test('empty text', async () => {
-    await expect(sentence_tokenizer("")).rejects.toThrow();
-  });
+// source of truth for tokenizing: https://platform.openai.com/tokenizer?view=bpe
+
+describe("split_text_by_tokens", () => {
+  test("empty text", async () => {
+    expect(await split_text_by_tokens("", 10)).toEqual([])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("1 token chunking without overlap", async () => {
+    expect(await split_text_by_tokens("Hello world! This is a test.", 1)).toEqual(
+      ["Hello", " world", "!", " This", " is", " a", " test", "."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("2 token chunking without overlap; odd number of tokens", async () => {
+    expect(await split_text_by_tokens("Hello world! This is still a test.", 2)).toEqual(
+      ["Hello world", "! This", " is still", " a test", "."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("whitespace", async () => {
+    expect(await split_text_by_tokens(" \n ", 1)).toEqual([" ", "\n", " "])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("2 token chunking with 1 overlap", async () => {
+    expect(await split_text_by_tokens("Hello world! This is a test.", 2, 1)).toEqual(
+      ["Hello world", " world!", "! This", " This is", " is a", " a test", " test."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("2 token chunking with 1 overlap; odd number of tokens", async () => {
+    expect(await split_text_by_tokens("Hello world! This is still a test.", 2, 1)).toEqual(
+      ["Hello world", " world!", "! This", " This is", " is still", " still a", " a test", " test."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("3 token chunking with 1 overlap", async () => {
+    expect(await split_text_by_tokens("Hello world! This is a test.", 3, 1)).toEqual(
+      ["Hello world!", "! This is", " is a test", " test."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("3 token chunking with 1 overlap; odd number of tokens", async () => {
+    expect(await split_text_by_tokens("Hello world! This is still a test.", 3, 1)).toEqual(
+      ["Hello world!", "! This is", " is still a", " a test."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("3 token chunking with 2 overlap", async () => {
+    expect(await split_text_by_tokens("Hello world! This is a test.", 3, 2)).toEqual(
+      ["Hello world!", " world! This", "! This is", " This is a", " is a test", " a test."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("3 token chunking with 2 overlap; odd number of tokens", async () => {
+    expect(await split_text_by_tokens("Hello world! This is still a test.", 3, 2)).toEqual(
+      ["Hello world!", " world! This", "! This is", " This is still", " is still a", " still a test", " a test."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("chunk size equal to text length returns single chunk with text", async () => {
+    expect(await split_text_by_tokens("Hello world! This is a test.", 8)).toEqual(
+      ["Hello world! This is a test."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("chunk size equal to text length returns single chunk with text, despite chunk_overlap", async () => {
+    expect(await split_text_by_tokens("Hello world! This is a test.", 8, 1)).toEqual(
+      ["Hello world! This is a test."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("chunk size longer than text returns single chunk with text", async () => {
+    expect(await split_text_by_tokens("Hello world! This is a test.", 9)).toEqual(
+      ["Hello world! This is a test."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("chunk size longer than text returns single chunk with text, despite chunk_overlap", async () => {
+    expect(await split_text_by_tokens("Hello world! This is a test.", 9, 1)).toEqual(
+      ["Hello world! This is a test."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("large chunk size and large chunk overlap", async () => {
+    expect(await split_text_by_tokens("Hello world! This is a test.", 7, 6)).toEqual(
+      ["Hello world! This is a test", " world! This is a test."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("large chunk size and small chunk overlap", async () => {
+    expect(await split_text_by_tokens("Hello world! This is a test.", 7, 1)).toEqual(
+      ["Hello world! This is a test", " test."])
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("chunk overlap larger than chunk size throws error", async () => {
+    expect(split_text_by_tokens("Hello world! This is still a test.", 2, 3)).rejects.toThrow("chunk_overlap must be less than chunk_size")
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("chunk overlap equal chunk size throws error", async () => {
+    expect(split_text_by_tokens("Hello world! This is still a test.", 3, 3)).rejects.toThrow("chunk_overlap must be less than chunk_size")
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("chunk size 0 with empty text", async () => {
+    expect(split_text_by_tokens("", 0)).rejects.toThrow("chunk_overlap must be less than chunk_size")
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("chunk size 0 with non-empty text", async () => {
+    expect(split_text_by_tokens("a", 0)).rejects.toThrow("chunk_overlap must be less than chunk_size")
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("negative chunk size throws", async () => {
+    expect(split_text_by_tokens("test", -1, -2)).rejects.toThrow("chunk_size must be non-negative")
+  })
+});
+
+describe("split_text_by_tokens", () => {
+  test("negative overlap throws", async () => {
+    expect(split_text_by_tokens("test", 0, -1)).rejects.toThrow("chunk_overlap must be non-negative")
+  })
 });

--- a/src/activities/tokenizer.ts
+++ b/src/activities/tokenizer.ts
@@ -85,6 +85,44 @@ export async function gpt3_detokenize(tokens: number[]): Promise<string> {
   return text;
 }
 
+/**
+ * Split text into chunks of the given token size.
+ * Adjacent chunks will overlap by chunk_overlap tokens, which can naively help avoid splitting
+ * in bad places.
+ * 
+ * @param text string to split into chunks
+ * @param chunk_size number of tokens per chunk (last chunk may be smaller)
+ * @param chunk_overlap number of tokens to overlap adjacent chunks. defaults to 0.
+ */
+export async function split_text_by_tokens(text: string, chunk_size: number, chunk_overlap: number = 0): Promise<string[]> {
+  if (chunk_size < 0) {
+    throw new Error("chunk_size must be non-negative");
+  }
+  if (chunk_overlap < 0) {
+    throw new Error("chunk_overlap must be non-negative");
+  }
+  if (chunk_overlap >= chunk_size) {
+    throw new Error("chunk_overlap must be less than chunk_size");
+  }
+
+  let chunks: string[] = [];
+  let text_tokens: number[] = await gpt3_tokenize( text );
+  console.log(`Tokenized ${text.length} characters into ${text_tokens.length} tokens.`);
+
+  // window slides by chunk_size - chunk_overlap tokens each iteration.
+  // we stop sliding when a chunk includes the last token
+  let tok_len = text_tokens.length;
+  for ( let idx = 0;
+        idx < tok_len && idx + chunk_overlap < tok_len; // rhs of && ensures last token only included once
+        idx += chunk_size - chunk_overlap )
+  {
+      let context_tokens_slice: number[] = text_tokens.slice(idx, idx + chunk_size);
+      let context_slice = await gpt3_detokenize( context_tokens_slice );
+      chunks.push( context_slice );
+  }
+  return chunks;
+}
+
 export async function sentence_tokenizer( text: String ): Promise< string[] > {
   throw new Error("Not implemented" );
 }


### PR DESCRIPTION
this PR adds a sliding window text splitter.

I manually verified that the first chunking of a long text looks correct when overlap is set to 0 tokens, and when set to 1 token. in theory this was a redundant manual verification due to the unit tests this PR also adds.

I did not update sql2llm to use an overlap. I'm not sure what a good default would be. given the default chunk size is 2048 tokens, maybe 128/256/512 could be good defaults?

